### PR TITLE
Potential fix for code scanning alert no. 3: Use of insecure SSL/TLS version

### DIFF
--- a/src/listener.http/src/run.py
+++ b/src/listener.http/src/run.py
@@ -65,6 +65,7 @@ def main():
                 return -1
 
             ctx = SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(tls_crt_file, tls_key_file)
             server.socket = ctx.wrap_socket(
                 server.socket, 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/dusseldorf/security/code-scanning/3](https://github.com/microsoft/dusseldorf/security/code-scanning/3)

To fix the problem, we need to ensure that the SSL/TLS context explicitly uses a secure version of the protocol, such as TLS 1.2 or above. We can achieve this by setting the `minimum_version` attribute of the `SSLContext` to `ssl.TLSVersion.TLSv1_2`. This change will ensure that only TLS 1.2 or higher versions are used for the connection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
