### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/dusseldorf/api/src/api/middleware/error_handler.py
+++ b/dusseldorf/api/src/api/middleware/error_handler.py
@@ -26,14 +26,14 @@ async def error_handler_middleware(
             "type": type(e).__name__,
         }
         
-        if request.app.debug:
-            error_detail["traceback"] = traceback.format_exc()
-            
         return JSONResponse(
             status_code=500,
             content={
                 "success": False,
-                "error": error_detail,
+                "error": {
+                    "message": "An internal error has occurred.",
+                    "type": "InternalServerError"
+                },
                 "path": str(request.url)
             }
-        ) 
+        )


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/dusseldorf/security/code-scanning/4](https://github.com/microsoft/dusseldorf/security/code-scanning/4)

To fix the problem, we should ensure that detailed error information, including stack traces, is not exposed to the end user, even in debug mode. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by removing the traceback from the error response and ensuring that only a generic message is returned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
