### PR TITLE
remove dots from autosuggested zones

### DIFF
--- a/dusseldorf/ui/README.md
+++ b/dusseldorf/ui/README.md
@@ -1,7 +1,8 @@
 # Dusseldorf UI
-Admin UI for [Dusseldorf](https://aka.ms/dusseldorf).
+This is the graphical user interface for [Dusseldorf](https://aka.ms/dusseldorf), which provides an easy 
+human way to interface with Dusseldorf's API. 
 
-This runs as its own component, it's a static web page build in the React Framework, hosted on https://dusseldorf.security.azure/ 
+This runs as its own component, it's a static web page build in the React Framework, hosted as a static component within the API repository. 
 
 # Running Locally
 
@@ -13,16 +14,14 @@ $ npm test # <-- this runs our tests, to make sure your site will run.
 $ npm start 
 ```
 
-Then go to localhost:3000 to see the UI working.  It WILL connect to the following endpoint `https://api.dusseldorf.security.azure/`.  You can override it if needed, by setting the `api_host` key in localstorage to an HTTPS (!) endopint.  For canary, you can use: 
+Then go to localhost:3000 to see the UI working.  It will connect to a relative endpoint being `api/`, as this is the default 
+location of the API.  You can override it if needed, by setting the `api_host` key in localstorage.  For example, you can do the following: 
 
- * Canary API : `https://api.dusseldorf.security.azure/` 
-
-Simply execute `localStorage['api_host'] = "your.api.endpoint"` in the console of the DevTools in your favourite browser to any value to change whwhich API endpoint you talk to.  For example, in your favourite browser; press F12 and co to the *console*, and type:
 ``` javascript
 localStorage['api_host'] = "localhost:5001"
 ```
-If you want the API host to be localhost, on port 5001 (such as a local instance of Kestrel or Visual Studio).
+in the console of the DevTools in your favourite browser to any value to change which API endpoint you talk to. 
 
 # Design 
-This UI is build upon the amazing [FluentUI](https://developer.microsoft.com/en-us/fluentui#/) framework.
+This UI is build upon the amazing [Fluent2](https://fluent2.microsoft.design/) design framework.
 

--- a/dusseldorf/ui/src/Components/AddSingleZoneDialog.tsx
+++ b/dusseldorf/ui/src/Components/AddSingleZoneDialog.tsx
@@ -148,7 +148,7 @@ export const AddSingleZoneDialog = ({
             const numSubStr = Math.floor(Math.random() * 1000)
             .toString()
             .padStart(3, "0");
-            // remove the dots from the upn, so we don't create a foo.bar000 zone by by accident.
+            // remove the dots from the upn, so we don't create a foo.bar000 zone by accident.
             const upnSubstr = upn.substring(0, DEFAULT_SUBDOMAIN_LENGTH - 3).replace(/\./g, "");
 
             setSubdomain(upnSubstr + numSubStr);

--- a/dusseldorf/ui/src/Components/AddSingleZoneDialog.tsx
+++ b/dusseldorf/ui/src/Components/AddSingleZoneDialog.tsx
@@ -144,11 +144,12 @@ export const AddSingleZoneDialog = ({
         if (open && subdomain.length == 0) {
             const account = instance.getActiveAccount();
             const upn = account?.username.split("@")[0] ?? "";
-
+            
             const numSubStr = Math.floor(Math.random() * 1000)
-                .toString()
-                .padStart(3, "0");
-            const upnSubstr = upn.substring(0, DEFAULT_SUBDOMAIN_LENGTH - 3);
+            .toString()
+            .padStart(3, "0");
+            // remove the dots from the upn, so we don't create a foo.bar000 zone by by accident.
+            const upnSubstr = upn.substring(0, DEFAULT_SUBDOMAIN_LENGTH - 3).replace(/\./g, "");
 
             setSubdomain(upnSubstr + numSubStr);
         }

--- a/dusseldorf/ui/src/Components/AddSingleZoneDialog.tsx
+++ b/dusseldorf/ui/src/Components/AddSingleZoneDialog.tsx
@@ -145,11 +145,15 @@ export const AddSingleZoneDialog = ({
             const account = instance.getActiveAccount();
             const upn = account?.username.split("@")[0] ?? "";
             
+            // remove any dots from the upn, so we don't create a `foo.bar000` zone by accident.
+            let upnSubstr = upn.replace(/\./g, "");
+
+            // If the UPN is too long, truncate it to the first X characters
+            upnSubstr = upnSubstr.substring(0, DEFAULT_SUBDOMAIN_LENGTH - 3);
+
             const numSubStr = Math.floor(Math.random() * 1000)
             .toString()
             .padStart(3, "0");
-            // remove the dots from the upn, so we don't create a foo.bar000 zone by accident.
-            const upnSubstr = upn.substring(0, DEFAULT_SUBDOMAIN_LENGTH - 3).replace(/\./g, "");
 
             setSubdomain(upnSubstr + numSubStr);
         }


### PR DESCRIPTION
When I did some testing in nullcon, my michael.hendrickx@... email turned into a `michael.he000`-like subdomain, which prevents someone (even myself) from claiming the zone `he000`...

Plus, in the DNS readme, there were some internal references that would mislead users.

