### PR TITLE
adding copy button again to the zone title in the web UI

### DIFF
--- a/dusseldorf/ui/src/screens/ZoneDetailsScreen.tsx
+++ b/dusseldorf/ui/src/screens/ZoneDetailsScreen.tsx
@@ -11,6 +11,7 @@ import { AuthDialog } from "../Components/ZoneDetails/AuthDialog";
 import { DeleteZoneDialog } from "../Components/ZoneDetails/DeleteZoneDialog";
 import { QRCodeDialog } from "../Components/ZoneDetails/QRCodeDialog";
 import { OpenInNewTabButton } from "../Components/OpenInNewTabButton";
+import { CopyButton } from "../Components/CopyButton";
 
 const useStyles = makeStyles({
     root: {
@@ -57,6 +58,8 @@ export const ZoneDetailsScreen = ({ showRules = false }: ZoneDetailsScreenProps)
                 >
                     {zone}
                 </Title2>
+
+                <CopyButton text={zone} />
 
                 <OpenInNewTabButton url={zone} />
 


### PR DESCRIPTION
Adding the "copy" button again to make it easier to copy a zone. :) 

(Sorry Erik, who removed it in lieu of the "open in new tab" button.) 