### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/dusseldorf/security/code-scanning/6](https://github.com/microsoft/dusseldorf/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs read operations (e.g., checking out the code and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to execute the workflow.

The changes will be made at the top of the workflow file, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
