### PR TITLE
Pin JWT validation to RSA algorithms

### DIFF
--- a/dusseldorf/api/src/api/services/azure_ad.py
+++ b/dusseldorf/api/src/api/services/azure_ad.py
@@ -76,7 +76,6 @@ class AzureADService:
         try:
             # First decode without verification to get the key ID
             unverified_headers = jwt.get_unverified_header(token)
-            alg = unverified_headers.get("alg")
             kid = unverified_headers.get("kid")
             if not kid:
                 raise ValueError("No key ID in token header")
@@ -86,11 +85,14 @@ class AzureADService:
             if kid not in signing_keys:
                 raise ValueError("Unknown key ID")
 
-            # Decode and validate token
+            # Decode and validate token — only allow RSA algorithms to prevent
+            # algorithm confusion attacks (CWE-347). Never trust the token's
+            # own "alg" header as it is attacker-controlled. Azure AD uses RS256
+            # but we accept RS384/RS512 as well for forward compatibility.
             claims = jwt.decode(
                 token,
                 key=signing_keys[kid],
-                algorithms=[alg],
+                algorithms=["RS256", "RS384", "RS512"],
                 audience=self.settings.AZURE_CLIENT_ID
             )
             


### PR DESCRIPTION
## Summary

Hardcodes the allowed algorithm list in `jwt.decode()` instead of reading it from the unverified token header. Currently the `alg` field from the token is passed directly to `algorithms=[alg]`, which means the caller trusts attacker-controlled input to select the verification algorithm.

Pins to `RS256`, `RS384`, `RS512` — the RSA family used by Azure AD. This blocks symmetric algorithms (HS256/384/512) and `none`. RS384/RS512 are included alongside RS256 for forward compatibility if the IdP configuration changes.

## Changes

**`dusseldorf/api/src/api/services/azure_ad.py`:**

- Remove `alg = unverified_headers.get('alg')`
- Change `algorithms=[alg]` to `algorithms=['RS256', 'RS384', 'RS512']`

## Testing

- Existing tests pass
- Legitimate RS256 tokens from Azure AD continue to validate