### PR TITLE
Accept managed-identity / service-principal tokens for API auth

### DIFF
--- a/dusseldorf/api/src/api/config.py
+++ b/dusseldorf/api/src/api/config.py
@@ -16,6 +16,10 @@ class Settings(BaseSettings):
     # Azure
     AZURE_TENANT_ID: str
     AZURE_CLIENT_ID: str
+    # Audience for inbound token validation; defaults to AZURE_CLIENT_ID.
+    # Set when callers authenticate with a managed identity / service
+    # principal whose token audience differs from the app id.
+    DSSLDRF_API_AUDIENCE: str = ""
 #    AZURE_CLIENT_SECRET: str
 #    KEY_VAULT_URL: str
     

--- a/dusseldorf/api/src/api/models/auth.py
+++ b/dusseldorf/api/src/api/models/auth.py
@@ -5,9 +5,29 @@
 # aka.ms/dusseldorf
 
 from enum import IntEnum
-from pydantic import BaseModel, EmailStr
-from typing import Optional
+from typing import Annotated, Optional
+from uuid import UUID
 from datetime import datetime
+from pydantic import AfterValidator, BaseModel, EmailStr, TypeAdapter, ValidationError
+
+
+_email_validator = TypeAdapter(EmailStr)
+
+
+def _validate_alias(value: str) -> str:
+    """An authz principal is a user's email or a service identity's GUID (OID/appId)."""
+    try:
+        _email_validator.validate_python(value)
+    except ValidationError:
+        try:
+            UUID(value)
+        except ValueError:
+            raise ValueError("alias must be an email address or a GUID")
+    return value
+
+
+# Accepts a human (email) or a managed identity / service principal (GUID).
+EmailOrGuid = Annotated[str, AfterValidator(_validate_alias)]
 
 class Permission(IntEnum):
     NOPERMISSION = -999
@@ -18,14 +38,14 @@ class Permission(IntEnum):
 
 
 class AuthzBase(BaseModel):
-    alias: EmailStr
+    alias: EmailOrGuid
     authzlevel: int #IntEnum?
 
 class AuthzPermission(AuthzBase):
     pass
 
 class PermissionRequest(BaseModel):
-    alias: EmailStr
+    alias: EmailOrGuid
     permission: str
     # permission: Permission
 

--- a/dusseldorf/api/src/api/services/azure_ad.py
+++ b/dusseldorf/api/src/api/services/azure_ad.py
@@ -91,7 +91,7 @@ class AzureADService:
                 token,
                 key=signing_keys[kid],
                 algorithms=[alg],
-                audience=self.settings.AZURE_CLIENT_ID
+                audience=self.settings.DSSLDRF_API_AUDIENCE or self.settings.AZURE_CLIENT_ID
             )
             
             # Verify tenant ID
@@ -104,17 +104,26 @@ class AzureADService:
             if not oid:
                 raise ValueError("No object ID in token")
 
+            # Accept the v2.0 issuer (user tokens) and the v1.0 sts.windows.net
+            # issuer that managed-identity / service-principal tokens use.
             iss = claims.get("iss")
-            if iss != f"https://login.microsoftonline.com/{self.settings.AZURE_TENANT_ID}/v2.0":
+            valid_issuers = (
+                f"https://login.microsoftonline.com/{self.settings.AZURE_TENANT_ID}/v2.0",
+                f"https://sts.windows.net/{self.settings.AZURE_TENANT_ID}/",
+            )
+            if iss not in valid_issuers:
                 raise ValueError("Invalid issuer")
                 
-            # Return normalized user info (only what's needed)
+            # Return normalized user info (only what's needed). Managed-identity /
+            # service-principal tokens carry no preferred_username/email, so fall
+            # back to the object id (their stable identifier).
+            username = claims.get("preferred_username") or oid
             return {
                 "id": oid,  # Object ID (unique user identifier)
                 "tid": tid,  # Tenant ID
-                "preferred_username": claims.get("preferred_username"),  # User Principal Name
+                "preferred_username": username,  # UPN, or OID for service identities
                 "name": claims.get("name"),
-                "email": claims.get("email") or claims.get("preferred_username"),
+                "email": claims.get("email") or username,
                 "roles": claims.get("roles", [])
             }
             


### PR DESCRIPTION
Today the API only accepts human Entra v2.0 user tokens. This lets it also accept Azure managed-identity / service-principal tokens, so an automated caller (e.g. a VM's system-assigned identity) can reach the API without a signed-in user.

- **config**: optional `DSSLDRF_API_AUDIENCE` (defaults to `AZURE_CLIENT_ID`)
- **azure_ad**: also accept the v1.0 `sts.windows.net` issuer; fall back to the
  object id when a token has no `preferred_username`/`email`
- **auth**: an authz `alias` can be an email *or* a GUID (service identity)

This is backward-compatible, user tokens validate exactly as before. Builds on #69.
