### PR TITLE
Refactor ACR publish workflow to use Docker build

### DIFF
--- a/.github/workflows/acr-publish.yml
+++ b/.github/workflows/acr-publish.yml
@@ -1,43 +1,26 @@
-name: Build and Push Container Images ACR
+name: Build Container Images
 on:
   push:
     branches: [ "main" ]
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Az CLI login'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Checkout code
         uses: actions/checkout@main
 
-      - name: Build and push DNS listener image
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az acr build --image gh-dns-listener:${{ github.sha }} --registry ${{ secrets.REGISTRY_LOGIN_SERVER }} --file dusseldorf/dns-listener_Dockerfile ./dusseldorf
+      - name: Build DNS listener image
+        run:
+          docker build -t gh-dns-listener:${{ github.sha }} --file dusseldorf/dns-listener_Dockerfile ./dusseldorf
 
-      - name: Build and push HTTP listener image
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az acr build --image gh-http-listener:${{ github.sha }} --registry ${{ secrets.REGISTRY_LOGIN_SERVER }} --file dusseldorf/http-listener_Dockerfile ./dusseldorf
-
-      - name: Build and push API image
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az acr build --image gh-api:${{ github.sha }} --registry ${{ secrets.REGISTRY_LOGIN_SERVER }} --file dusseldorf/api_Dockerfile ./dusseldorf
+      - name: Build HTTP listener image
+        run:
+          docker build -t gh-http-listener:${{ github.sha }} --file dusseldorf/http-listener_Dockerfile ./dusseldorf
+      
+      - name: Build API image
+        run:
+          docker build -t gh-api:${{ github.sha }} --file dusseldorf/api_Dockerfile ./dusseldorf


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building container images. The main change is that it removes the use of Azure CLI and ACR (Azure Container Registry) for building and pushing images, and instead builds the Docker images locally using the `docker build` command. The workflow no longer logs into Azure or pushes images to ACR as part of this process.

Workflow simplification:

* Removed all Azure CLI login and ACR build steps, including Azure credentials and permissions, from `.github/workflows/acr-publish.yml`.
* Replaced the ACR-based image build and push steps with local Docker build commands for the DNS listener, HTTP listener, and API images.