### PR TITLE
Fix(a11y): give rule Select an accessible name when inline editing (AB#2643)

### DIFF
--- a/dusseldorf/ui/src/Components/Rules/RuleComponents/GenericRuleComponent.tsx
+++ b/dusseldorf/ui/src/Components/Rules/RuleComponents/GenericRuleComponent.tsx
@@ -112,6 +112,7 @@ export const GenericRuleComponent = ({
                     actionName={actionName}
                     value={value}
                     setValue={setValue}
+                    ariaLabel={fieldLabelDictionary[isPredicate ? 1 : 0][actionName] ?? ""}
                 />
             );
         } else if (actionName === "http.method") {

--- a/dusseldorf/ui/src/Components/Rules/RuleComponents/SelectRuleComponent.tsx
+++ b/dusseldorf/ui/src/Components/Rules/RuleComponents/SelectRuleComponent.tsx
@@ -10,9 +10,11 @@ interface SelectRuleComponentProps {
     actionName: string;
     value: string;
     setValue: (value: string) => void;
+    /** Accessible name for the control, used when no visible Field label is shown (e.g. inline editing). */
+    ariaLabel?: string;
 }
 
-export const SelectRuleComponent = ({ actionName, value, setValue }: SelectRuleComponentProps): JSX.Element => {
+export const SelectRuleComponent = ({ actionName, value, setValue, ariaLabel }: SelectRuleComponentProps): JSX.Element => {
     const [options, setOptions] = useState<JSX.Element[]>([]);
     const [localValue, setLocalValue] = useState<string>(value);
 
@@ -46,6 +48,7 @@ export const SelectRuleComponent = ({ actionName, value, setValue }: SelectRuleC
 
     return (
         <Select
+            aria-label={ariaLabel}
             value={localValue}
             onChange={(_, data) => {
                 setValue(data.value);


### PR DESCRIPTION
When editing an existing rule component the Field label is intentionally blanked, which left the **Set HTTP code** (and DNS type) `Select` with no accessible name - screen readers announced only 'combo box' (WCAG 4.1.2). Passes the human-readable field label to the `Select` as an `aria-label` so it has an accessible name with no visible layout change.

Files: `ui/src/Components/Rules/RuleComponents/SelectRuleComponent.tsx`, `ui/src/Components/Rules/RuleComponents/GenericRuleComponent.tsx`

---
_Validated locally: `npm test` passes (3 suites / 6 tests); introduces no new `npm run lint` errors vs. `main`._