### PR TITLE
Keep Request Details pane steady while Network Requests scrolls

### DIFF
--- a/dusseldorf/ui/src/screens/ZoneDetailsScreen.tsx
+++ b/dusseldorf/ui/src/screens/ZoneDetailsScreen.tsx
@@ -20,7 +20,21 @@ const useStyles = makeStyles({
         padding: "20px",
         width: "100%",
         minWidth: "500px",
-        overflowX: "hidden"
+        // Fill the parent content row and become a vertical flex container so the
+        // requests/rules area can own its own scrolling instead of the whole
+        // screen scrolling as one block.
+        height: "100%",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden"
+    },
+    content: {
+        // Take the remaining height below the header/divider. minHeight: 0 lets
+        // this flex child shrink so its scrollable descendants activate their
+        // own overflow instead of stretching the whole screen.
+        flexGrow: 1,
+        minHeight: 0
     },
     header: {
         display: "flex",
@@ -114,7 +128,7 @@ export const ZoneDetailsScreen = ({ showRules = false }: ZoneDetailsScreenProps)
 
             <Divider className={styles.divider} />
 
-            <div>
+            <div className={styles.content}>
                 {
                     showRules ? (
                         <RulesScreen zone={zone} />


### PR DESCRIPTION
The zone details screen scrolled as one block: the root container set only `overflow-x: hidden`, which per CSS forces `overflow-y` to compute to `auto`, so the header, the Network Requests list and the Request Details pane all scrolled together. On zones with many (100+) requests, scrolling down to reach older requests pushed the Request Details pane completely out of view.

Make the root a bounded, full-height flex column and give the requests/rules area `flex-grow: 1; min-height: 0`. This lets the existing `overflow: auto` panes inside ResizableSplitPanel own their scrolling, so the middle Network Requests list scrolls independently while the Request Details pane stays fixed.

**Before fix:**
<img width="1000" height="625" alt="before-fix" src="https://github.com/user-attachments/assets/6fe7f689-36d4-4802-8afe-e08823e88fc0" />

**After fix:**
<img width="1000" height="625" alt="after-fix" src="https://github.com/user-attachments/assets/8d6607de-0b71-4c4a-a5d8-1519bedb3a2c" />