### PR TITLE
Update MSAL package version to 1.37.0

### DIFF
--- a/dusseldorf/api/src/api/requirements.txt
+++ b/dusseldorf/api/src/api/requirements.txt
@@ -36,7 +36,7 @@ MarkupSafe==3.0.3
 mdurl==0.1.2
 mongomock==4.3.0
 motor==3.7.1
-msal==1.36.0
+msal==1.37.0
 msal-extensions==1.3.1
 msrest==0.7.1
 oauthlib==3.3.1

--- a/dusseldorf/listener.http/src/requirements.txt
+++ b/dusseldorf/listener.http/src/requirements.txt
@@ -24,7 +24,7 @@ importlib_metadata==8.7.1
 iniconfig==2.3.0
 isodate==0.7.2
 lxml==6.1.0
-msal==1.36.0
+msal==1.37.0
 msal-extensions==1.3.1
 msrest==0.7.1
 oauthlib==3.3.1


### PR DESCRIPTION
This pull request updates the `msal` dependency to version 1.37.0 in both the API and HTTP listener requirements files. This ensures consistency and brings in the latest features and fixes from the `msal` library.

Dependency updates:

* Upgraded `msal` from version 1.36.0 to 1.37.0 in `dusseldorf/api/src/api/requirements.txt`
* Upgraded `msal` from version 1.36.0 to 1.37.0 in `dusseldorf/listener.http/src/requirements.txt`